### PR TITLE
introduce shutdown function

### DIFF
--- a/examples/kv-server/src/main/java/com/yahoo/gondola/demo/DemoApplication.java
+++ b/examples/kv-server/src/main/java/com/yahoo/gondola/demo/DemoApplication.java
@@ -11,12 +11,17 @@ import com.yahoo.gondola.container.RoutingFilter;
 
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.URL;
 
 import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
 import javax.ws.rs.core.Context;
 
 /**
@@ -29,8 +34,12 @@ import javax.ws.rs.core.Context;
  * 4. Register the resources
  */
 public class DemoApplication extends ResourceConfig {
+    Gondola gondola;
+    static DemoApplication instance;
+    static Logger logger = LoggerFactory.getLogger(DemoApplication.class);
+
     public DemoApplication(@Context ServletContext servletContext) throws Exception {
-        Gondola gondola = initializeGondola();
+        gondola = initializeGondola();
 
         // Dependency injection to DemoResource
         DemoService demoService = new DemoService(gondola);
@@ -46,6 +55,11 @@ public class DemoApplication extends ResourceConfig {
 
         // register resources in the package
         packages(true, "com.yahoo.gondola.demo");
+        instance = this;
+    }
+
+    public static DemoApplication getInstance() {
+        return instance;
     }
 
     private Gondola initializeGondola() throws Exception {
@@ -59,5 +73,23 @@ public class DemoApplication extends ResourceConfig {
         Gondola gondola = new Gondola(config, hostId);
         gondola.start();
         return gondola;
+    }
+
+    /**
+     * Servlet 3.0 context listener, used to manage the lifecycle of the app.
+     */
+    @WebListener
+    public static class ContextListener implements ServletContextListener {
+        @Override
+        public void contextInitialized(ServletContextEvent sce) {
+            // doing nothing
+            logger.info("Demo application initialized");
+        }
+
+        @Override
+        public void contextDestroyed(ServletContextEvent sce) {
+            logger.info("Demo application destroyed");
+            DemoApplication.getInstance().gondola.stop();
+        }
     }
 }

--- a/examples/kv-server/src/main/resources/log4j.properties
+++ b/examples/kv-server/src/main/resources/log4j.properties
@@ -1,8 +1,0 @@
-# Root logger option
-log4j.rootLogger=INFO, stdout
-
-# Direct log messages to stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/examples/kv-server/src/main/resources/logback.xml
+++ b/examples/kv-server/src/main/resources/logback.xml
@@ -10,5 +10,7 @@
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
-    <logger name="com.yahoo.gondola" level="INFO"/>
+    <logger name="com.yahoo.gondola" level="ERROR"/>
+    <logger name="com.yahoo.gondola.container" level="INFO"/>
+    <logger name="com.yahoo.gondola.demo" level="INFO"/>
 </configuration>


### PR DESCRIPTION
Currently gondola.stop() will hang when destroy the webapp. need to investigate the root cause.
In the mean while, if application hangs, need to issue kill the process manually.

[INFO] Stopped ServerConnector@6ee37ca7{HTTP/1.1,[http/1.1]}{0.0.0.0:8080}
12:59:16.833 [Thread-1] INFO  c.yahoo.gondola.demo.DemoApplication - Demo application destroyed
12:59:16.841 [MainLoop-81] ERROR com.yahoo.gondola.impl.SystemClock - null
java.lang.InterruptedException: null
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.reportInterruptAfterWait(AbstractQueuedSynchronizer.java:2014) ~[na:1.8.0_65]
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2173) ~[na:1.8.0_65]
        at com.yahoo.gondola.impl.SystemClock.awaitCondition(SystemClock.java:45) ~[core-0.2.8-SNAPSHOT.jar:na]
        at com.yahoo.gondola.core.CoreMember$MainLoop.mainLoop(CoreMember.java:507) [core-0.2.8-SNAPSHOT.jar:na]
        at com.yahoo.gondola.core.CoreMember$MainLoop.run(CoreMember.java:391) [core-0.2.8-SNAPSHOT.jar:na]
