### PR TITLE
run jetty without require mvn install

### DIFF
--- a/examples/kv-server/pom.xml
+++ b/examples/kv-server/pom.xml
@@ -48,22 +48,18 @@
                     <webAppXml>${project.basedir}/src/main/webapp/WEB-INF/jetty-web.xml</webAppXml>
                     <webApp>
                         <contextPath>/api</contextPath>
+                        <extraClasspath>../../core/target/classes;../../containers/jersey2-routing/target/classes</extraClasspath>
                     </webApp>
                     <httpConnector>
                         <port>${jetty.port}</port>
                     </httpConnector>
+                    <scanTargets>
+                        <scanTarget>../../core/target/classes</scanTarget>
+                        <scanTarget>../../containers/jersey2-routing/target/classes</scanTarget>
+                    </scanTargets>
                     <env>
-                        <hostId>host2</hostId>
+                        <hostId>host1</hostId>
                     </env>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,10 @@
                     </properties>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
speed up the development. now it doesn't require running `mvn install` all the time if change a dependency in kv-server example.