### PR TITLE
Fixed slaving issue

### DIFF
--- a/core/src/main/java/com/yahoo/gondola/Member.java
+++ b/core/src/main/java/com/yahoo/gondola/Member.java
@@ -173,6 +173,8 @@ public class Member {
      *
      * If masterAddress is -1, this member leaves slave mode.
      *
+     * Any waiters for committed commands will get a SLAVE_MODE exception when slave is entered.
+     *
      * @param masterId the member id of the leader to sync with. Set to -1 to leave slave mode.
      */
     public void setSlave(int masterId) throws GondolaException, InterruptedException {

--- a/core/src/main/java/com/yahoo/gondola/core/CommitQueue.java
+++ b/core/src/main/java/com/yahoo/gondola/core/CommitQueue.java
@@ -126,11 +126,6 @@ public class CommitQueue {
      */
     public void get(CoreCmd ccmd, int index, int timeout)
             throws InterruptedException, TimeoutException, GondolaException {
-        // Gets are not allowed in slave mode
-        if (cmember.masterId >= 0) {
-            throw new GondolaException(GondolaException.Code.SLAVE_MODE, cmember.memberId);
-        }
-
         // Get latest saved index
         cmember.saveQueue.getLatestWait(cmember.savedRid);
 
@@ -195,14 +190,6 @@ public class CommitQueue {
             ccmd = getQueue.remove();
             ccmd.update(Command.STATUS_SLAVE_MODE, cmember.leaderId);
             ccmd = getQueue.peek();
-        }
-
-        // Clear out command queue
-        ccmd = commandQueue.peek();
-        while (ccmd != null) {
-            ccmd = commandQueue.remove();
-            ccmd.update(Command.STATUS_SLAVE_MODE, cmember.leaderId);
-            ccmd = commandQueue.peek();
         }
     }
 

--- a/core/src/main/java/com/yahoo/gondola/core/CoreMember.java
+++ b/core/src/main/java/com/yahoo/gondola/core/CoreMember.java
@@ -1374,6 +1374,9 @@ public class CoreMember implements Stoppable {
                         peers.clear();
                         peerMap.clear();
 
+                        // Destroy any slaves
+                        shutdownSlaves();
+
                         // Prepare to talk to new master
                         if (masterId >= 0) {
                             // Make sure this member and the master are not in the same shard
@@ -1443,7 +1446,8 @@ public class CoreMember implements Stoppable {
     /**
      * Called by the Network system when there's a connection request
      * from a slave.  If this member accepts the channel, true is
-     * returned.  If the channel is not accepted, false should be
+     * returned.  The member will be responsible for starting the channel.
+     * If the channel is not accepted, false should be
      * returned and the caller will take care of closing the channel.
      *
      * @param channel non-null channel to the slave.

--- a/core/src/main/java/com/yahoo/gondola/core/CoreMember.java
+++ b/core/src/main/java/com/yahoo/gondola/core/CoreMember.java
@@ -492,6 +492,9 @@ public class CoreMember implements Stoppable {
                             }
                             updateWaitingCommands();
                             break;
+                        case FORCE_HEARTBEAT:
+                            sendHeartbeat(true);
+                            break;
                         case EXECUTE:
                             action.futureTask.run();
                             break;
@@ -1371,8 +1374,8 @@ public class CoreMember implements Stoppable {
                         for (Peer peer : peers) {
                             peer.stop();
                         }
-                        peers.clear();
-                        peerMap.clear();
+                        peers = new ArrayList<>(); // Don't use clear to avoid sync issues
+                        peerMap = new HashMap<>(); // Don't use clear to avoid sync issues
 
                         // Destroy any slaves
                         shutdownSlaves();
@@ -1493,6 +1496,7 @@ public class CoreMember implements Stoppable {
         slaves.add(slave);
         try {
             slave.start();
+            actionQueue.forceHeartbeat();
         } catch (GondolaException e) {
             logger.error("Could not start slave", e);
             slaves.remove(slave);
@@ -1509,6 +1513,6 @@ public class CoreMember implements Stoppable {
         for (Peer slave : slaves) {
             slave.stop();
         }
-        slaves.clear();
+        slaves = new ArrayList<>(); // Don't use clear to avoid sync issues
     }
 }

--- a/core/src/main/java/com/yahoo/gondola/core/CoreMemberActionQueue.java
+++ b/core/src/main/java/com/yahoo/gondola/core/CoreMemberActionQueue.java
@@ -28,6 +28,7 @@ public class CoreMemberActionQueue {
         BECOME_FOLLOWER,
         UPDATE_SAVED_INDEX,
         UPDATE_STORAGE_INDEX,
+        FORCE_HEARTBEAT,
         EXECUTE,
     }
 
@@ -55,6 +56,14 @@ public class CoreMemberActionQueue {
 
     public void updateStorageIndex() {
         queue.add(new Action(Type.UPDATE_STORAGE_INDEX));
+    }
+
+    /**
+     * Used when adding a slave. Heartbeats are not sent when the server is under load.
+     * This will allow a heartbeat to get through to the new slave.
+     */
+    public void forceHeartbeat() {
+        queue.add(new Action(Type.FORCE_HEARTBEAT));
     }
 
     public void execute(Runnable runnable) throws GondolaException, InterruptedException {

--- a/core/src/main/java/com/yahoo/gondola/core/Peer.java
+++ b/core/src/main/java/com/yahoo/gondola/core/Peer.java
@@ -622,7 +622,6 @@ public class Peer {
         } finally {
             lock.unlock();
         }
-
     }
 
     /**

--- a/core/src/test/java/com/yahoo/gondola/core/GondolaTest.java
+++ b/core/src/test/java/com/yahoo/gondola/core/GondolaTest.java
@@ -1009,6 +1009,21 @@ public class GondolaTest {
         member3.setFollower();
         runningTick = 50;
 
+        Thread writer = new Thread() {
+                public void run() {
+                    try {
+                        long start = System.currentTimeMillis();
+                        while (System.currentTimeMillis() - start < 15000) {
+                            commit(member1, "testing");
+                            Thread.sleep(1);
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            };
+        writer.start();
+
         // Create slave1
         Gondola g1 = new Gondola(gondolaRc.getConfig(), "D");
         gondolaRc.add(g1);

--- a/core/src/test/java/com/yahoo/gondola/rc/GondolaRc.java
+++ b/core/src/test/java/com/yahoo/gondola/rc/GondolaRc.java
@@ -148,4 +148,8 @@ public class GondolaRc {
     public MemberRc getMember(int memberId) {
         return members.get(memberId);
     }
+
+    public boolean supportsPauseDelivery() {
+        return gondolas.get(0).getNetwork() instanceof RcNetwork;
+    }
 }

--- a/core/src/test/java/com/yahoo/gondola/rc/MemberRc.java
+++ b/core/src/test/java/com/yahoo/gondola/rc/MemberRc.java
@@ -56,7 +56,7 @@ public class MemberRc {
     public Shard getShard() {
         return shard;
     }
-    
+
     public int getMemberId() {
         return cmember.getMemberId();
     }
@@ -64,7 +64,11 @@ public class MemberRc {
     public int getCommitIndex() {
         return cmember.getCommitIndex();
     }
-    
+
+    public int getSavedIndex() throws Exception {
+        return cmember.getSavedIndex();
+    }
+
     public void enable(boolean on) throws Exception {
         cmember.enable(on);
     }


### PR DESCRIPTION
where a master laster becomes a slave.  The fix is to clear out any slave peers of the master before itself becoming a slave.

Also removed the restriction that getCommand() cannot be called while in slave mode. The modified behavior is that getCommand() will get an exception when slave mode is entered but then can be called immediately after.